### PR TITLE
force: Add constructor CreateWithAccessToken

### DIFF
--- a/force/force.go
+++ b/force/force.go
@@ -56,6 +56,39 @@ func Create(version, clientId, clientSecret, userName, password, securityToken,
 	return forceApi, nil
 }
 
+func CreateWithAccessToken(version, clientId, accessToken, instanceUrl string) (*ForceApi, error) {
+	oauth := &forceOauth{
+		clientId:    clientId,
+		AccessToken: accessToken,
+		InstanceUrl: instanceUrl,
+	}
+
+	forceApi := &ForceApi{
+		apiResources:           make(map[string]string),
+		apiSObjects:            make(map[string]*SObjectMetaData),
+		apiSObjectDescriptions: make(map[string]*SObjectDescription),
+		apiVersion:             version,
+		oauth:                  oauth,
+	}
+
+	// We need to check for oath correctness here, since we are not generating the token ourselves.
+	if err := forceApi.oauth.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Init Api Resources
+	err := forceApi.getApiResources()
+	if err != nil {
+		return nil, err
+	}
+	err = forceApi.getApiSObjects()
+	if err != nil {
+		return nil, err
+	}
+
+	return forceApi, nil
+}
+
 // Used when running tests.
 func createTest() *ForceApi {
 	forceApi, err := Create(testVersion, testClientId, testClientSecret, testUserName, testPassword, testSecurityToken, testEnvironment)

--- a/force/force_test.go
+++ b/force/force_test.go
@@ -1,0 +1,50 @@
+package force
+
+import (
+	"github.com/nimajalali/go-force/sobjects"
+	"testing"
+)
+
+func TestCreateWithAccessToken(t *testing.T) {
+
+	// Manually grab an OAuth token, so that we can pass it into CreateWithAccessToken
+	oauth := &forceOauth{
+		clientId:      testClientId,
+		clientSecret:  testClientSecret,
+		userName:      testUserName,
+		password:      testPassword,
+		securityToken: testSecurityToken,
+		environment:   testEnvironment,
+	}
+
+	forceApi := &ForceApi{
+		apiResources:           make(map[string]string),
+		apiSObjects:            make(map[string]*SObjectMetaData),
+		apiSObjectDescriptions: make(map[string]*SObjectDescription),
+		apiVersion:             version,
+		oauth:                  oauth,
+	}
+
+	err := forceApi.oauth.Authenticate()
+	if err != nil {
+		t.Fatalf("Unable to authenticate: %#v", err)
+	}
+	if err := forceApi.oauth.Validate(); err != nil {
+		t.Fatalf("Oauth object is invlaid: %#v", err)
+	}
+
+	// We shouldn't hit any errors creating a new force instance and manually passing in these oauth details now.
+	newForceApi, err := CreateWithAccessToken(testVersion, testClientId, forceApi.oauth.AccessToken, forceApi.oauth.InstanceUrl)
+	if err != nil {
+		t.Fatalf("Unable to create new force api instance using pre-defined oauth details: %#v", err)
+	}
+	if err := newForceApi.oauth.Validate(); err != nil {
+		t.Fatalf("Oauth object is invlaid: %#v", err)
+	}
+
+	// We should be able to make a basic query now with the newly created object (i.e. the oauth details should be correctly usable).
+	_, err = newForceApi.DescribeSObject(&sobjects.Account{})
+	if err != nil {
+		t.Fatalf("Failed to retrieve description of sobject: %v", err)
+	}
+}


### PR DESCRIPTION
Supports creating a ForceAPI without passing the username/password when
we have pre-generated an access token.
